### PR TITLE
run travis on both 0.4 and 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release is 0.5 now, 0.4 still supported according to REQUIRE so should still be tested