### PR TITLE
Fix iterator tests to use dynamic values instead of hardcoded RNG values

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,19 +19,22 @@ end
 ### Iterator tests
 s = ResettableStacks.ResettableStack{}(Float64)
 Random.seed!(100)
+expected_values = Float64[]
 for i in 1:6
-    push!(s, rand())
+    v = rand()
+    push!(expected_values, v)
+    push!(s, v)
 end
+# Iterator returns values in reverse (LIFO) order
+reversed_expected = reverse(expected_values)
 for (i, c) in enumerate(s)
-    @test i==1 ? c == 0.6456910432314067 : true
-    @test i==2 ? c == 0.9675998379215747 : true
-    @test i==3 ? c == 0.06719317094984745 : true
-    @test i==4 ? c == 0.6609109399808133 : true
-    @test i==5 ? c == 0.19031281518127185 : true
-    @test i==6 ? c == 0.2601250914736861 : true
+    @test c == reversed_expected[i]
 end
+@test length(collect(s)) == 6
 reset!(s)
-push!(s, rand())
+new_val = rand()
+push!(s, new_val)
 for c in s
-    @test c==0.5459681993995775
+    @test c == new_val
 end
+@test length(collect(s)) == 1


### PR DESCRIPTION
## Summary

This PR fixes the CI failures caused by hardcoded random number values in the iterator tests.

### Root Cause

The iterator tests at `test/runtests.jl:25-37` were using `Random.seed!(100)` and comparing against hardcoded expected values like:
```julia
@test i==1 ? c == 0.6456910432314067 : true
@test i==2 ? c == 0.9675998379215747 : true
```

These values were generated with an older Julia RNG implementation. Modern Julia versions (1.10+) use a different RNG that produces different sequences for the same seed, causing all CI tests to fail.

### Fix

Instead of hardcoding expected values:
1. Store the randomly generated values when pushing them to the stack
2. Compare against those stored values during iteration
3. Account for the LIFO (reverse) iteration order of the stack

This approach:
- Tests the same iterator functionality (correct values in correct order)
- Is portable across all Julia versions
- Remains deterministic within a single test run

### Testing

- Tested locally on Julia 1.12.3 - all tests pass
- The fix is minimal and only affects the test file

cc @ChrisRackauckas

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)