### PR TITLE
Add eltype method and interface tests for JLArrays/BigFloat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,8 +11,10 @@ StaticArrays = "0.10, 0.11, 0.12, 1.0"
 julia = "1.6"
 
 [extras]
+ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Test", "Random", "ArrayInterface", "JLArrays"]

--- a/src/ResettableStacks.jl
+++ b/src/ResettableStacks.jl
@@ -6,7 +6,7 @@ const FULL_RESET_COUNT = 10000
 
 using StaticArrays
 
-import Base: isempty, length, push!, pop!, iterate
+import Base: isempty, length, push!, pop!, iterate, eltype
 
 include("core.jl")
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -13,6 +13,7 @@ isinplace(::ResettableStack{T, iip}) where {T, iip} = iip
 
 isempty(S::ResettableStack) = S.cur==0
 length(S::ResettableStack) = S.cur
+eltype(::Type{ResettableStack{T, iip}}) where {T, iip} = T
 
 function push!(S::ResettableStack, x)
     if S.cur==length(S.data)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using ResettableStacks
 using Test
 using Random
+using JLArrays
+using ArrayInterface
 
 S = ResettableStack{}(Tuple{Float64, Float64, Float64})
 
@@ -38,3 +40,99 @@ for c in s
     @test c == new_val
 end
 @test length(collect(s)) == 1
+
+### Interface tests
+
+# eltype tests
+@testset "eltype" begin
+    S = ResettableStack{}(Float64)
+    push!(S, 1.0)
+    @test eltype(S) == Float64
+    @test typeof(collect(S)) == Vector{Float64}
+
+    S2 = ResettableStack{}(BigFloat)
+    push!(S2, BigFloat(1.0))
+    @test eltype(S2) == BigFloat
+    @test typeof(collect(S2)) == Vector{BigFloat}
+
+    S3 = ResettableStack{}(Vector{Int})
+    push!(S3, [1, 2, 3])
+    @test eltype(S3) == Vector{Int}
+    @test typeof(collect(S3)) == Vector{Vector{Int}}
+end
+
+# BigFloat support tests
+@testset "BigFloat support" begin
+    S = ResettableStack{}(BigFloat)
+    push!(S, BigFloat("3.14159265358979323846264338327950288419716939937510"))
+    push!(S, BigFloat("2.71828182845904523536028747135266249775724709369995"))
+    @test pop!(S) == BigFloat("2.71828182845904523536028747135266249775724709369995")
+    @test length(S) == 1
+
+    # Test iteration
+    for item in S
+        @test item isa BigFloat
+    end
+
+    # Test reset
+    reset!(S)
+    @test isempty(S)
+end
+
+# JLArrays support tests (GPU-like arrays)
+@testset "JLArray support" begin
+    # Store JLArrays in a stack
+    S = ResettableStack{}(JLArray{Float64, 1})
+    x1 = JLArray([1.0, 2.0, 3.0])
+    x2 = JLArray([4.0, 5.0, 6.0])
+
+    push!(S, x1)
+    push!(S, x2)
+    @test length(S) == 2
+
+    result = pop!(S)
+    @test result isa JLArray{Float64, 1}
+
+    # Test iteration
+    for item in S
+        @test item isa JLArray{Float64, 1}
+    end
+
+    # Test reset
+    reset!(S)
+    @test isempty(S)
+end
+
+# copyat_or_push! tests with various types
+@testset "copyat_or_push! interface" begin
+    # Test with BigFloat arrays (in-place mode)
+    S = ResettableStack{true}(Tuple{BigFloat, Vector{BigFloat}, Vector{BigFloat}})
+    tuple1 = (BigFloat(1.0), BigFloat[1.0, 2.0, 3.0], BigFloat[4.0, 5.0, 6.0])
+    tuple2 = (BigFloat(2.0), BigFloat[7.0, 8.0, 9.0], BigFloat[10.0, 11.0, 12.0])
+
+    ResettableStacks.copyat_or_push!(S, tuple1)
+    ResettableStacks.copyat_or_push!(S, tuple2)
+    @test S.cur == 2
+
+    # Test with JLArrays (non-in-place mode)
+    S2 = ResettableStack{false}(Tuple{Float64, JLArray{Float64, 1}, JLArray{Float64, 1}})
+    t1 = (1.0, JLArray([1.0, 2.0, 3.0]), JLArray([4.0, 5.0, 6.0]))
+    t2 = (2.0, JLArray([7.0, 8.0, 9.0]), JLArray([10.0, 11.0, 12.0]))
+
+    ResettableStacks.copyat_or_push!(S2, t1)
+    ResettableStacks.copyat_or_push!(S2, t2)
+    @test S2.cur == 2
+    @test S2.data[1][2] isa JLArray
+end
+
+# ArrayInterface compatibility tests
+@testset "ArrayInterface compatibility" begin
+    S = ResettableStack{}(Float64)
+    for i in 1:5
+        push!(S, Float64(i))
+    end
+
+    # The internal data vector should work with ArrayInterface
+    @test ArrayInterface.can_setindex(S.data)
+    @test ArrayInterface.fast_scalar_indexing(S.data)
+end


### PR DESCRIPTION
## Summary

- Add `Base.eltype` method for `ResettableStack` to properly return element type `T`. This fixes `collect(S)` returning `Vector{Any}` instead of `Vector{T}`.
- Add test dependencies: JLArrays and ArrayInterface (in extras section)
- Add comprehensive interface tests for SciML array/number interface compliance

## What was tested

1. **JLArray support (GPU-like arrays)**: All core operations work with JLArrays including push!, pop!, iteration, reset!, and copyat_or_push!
2. **BigFloat support (arbitrary precision)**: All operations work with BigFloat for full numeric type genericity
3. **ArrayInterface compatibility**: The internal data vector works correctly with ArrayInterface functions
4. **eltype/collect behavior**: After adding the eltype method, `collect(S)` now returns the correctly typed vector

## Issue found and fixed

The package was missing a `Base.eltype` method for `ResettableStack`. This caused:
- `eltype(S)` to return `Any` instead of the actual element type `T`
- `collect(S)` to return `Vector{Any}` instead of `Vector{T}`

The fix adds a single line to `src/core.jl`:
```julia
eltype(::Type{ResettableStack{T, iip}}) where {T, iip} = T
```

## Test plan

- [x] Run `Pkg.test()` - all tests pass
- [x] Test with JLArrays for GPU-like interface compliance
- [x] Test with BigFloat for arbitrary precision support
- [x] Test copyat_or_push! with various types
- [x] Verify eltype and collect work correctly

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)