### PR TITLE
Documentation improvements: Fix typos, update examples, and add comprehensive docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,28 +10,30 @@ will "reset" the stack, allowing it to write over its previous data. This
 allows you to reset the stack while avoiding garbage collection which can greatly
 improve performance in certain use cases. Every `FULL_RESET_COUNT` resets, it
 does a full reset, which is useful if the stack got very large for some reason
-and it no longer needs to be that large (while minimizing garbage control costs).
+and it no longer needs to be that large (while minimizing garbage collection costs).
 
 ## Installation
 
 To install the package, simply use:
 
 ```julia
+using Pkg
 Pkg.add("ResettableStacks")
 using ResettableStacks
 ```
 
-For the latest version, checkout master via:
+For the latest development version:
 
 ```julia
-Pkg.checkout("ResettableStacks")
+using Pkg
+Pkg.add(url="https://github.com/SciML/ResettableStacks.jl")
 ```
 
 ## Usage
 
 ```julia
 using ResettableStacks
-S = ResettableStack{}(Tuple{Float64, Float64, Float64})
+S = ResettableStack{true}(Tuple{Float64, Float64, Float64})
 
 push!(S, (0.5, 0.4, 0.3))
 push!(S, (0.5, 0.4, 0.4))

--- a/src/core.jl
+++ b/src/core.jl
@@ -1,3 +1,38 @@
+"""
+    ResettableStack{T, iip}
+
+A stack data structure that can be efficiently reset without triggering garbage collection.
+
+The stack maintains an internal buffer that is reused across resets, avoiding memory allocations
+and garbage collection overhead. Every `FULL_RESET_COUNT` resets, the internal buffer is resized
+if it has grown significantly larger than needed.
+
+# Type Parameters
+- `T`: The element type stored in the stack
+- `iip`: Boolean flag indicating if elements should be treated as in-place (true) or out-of-place (false)
+
+# Fields
+- `data::Vector{T}`: Internal buffer storing stack elements
+- `cur::Int`: Current position in the stack (number of elements)
+- `numResets::Int`: Counter tracking the number of times `reset!` has been called
+
+# Constructors
+```julia
+ResettableStack(::Type{T})          # Creates a stack with iip=true
+ResettableStack{iip}(::Type{T})     # Creates a stack with specified iip flag
+```
+
+# Example
+```julia
+S = ResettableStack{true}(Float64)
+push!(S, 1.0)
+push!(S, 2.0)
+val = pop!(S)  # returns 2.0
+reset!(S)      # efficiently resets the stack
+```
+
+See also: [`reset!`](@ref), [`push!`](@ref), [`pop!`](@ref)
+"""
 mutable struct ResettableStack{T, iip}
     data::Vector{T}
     cur::Int
@@ -64,6 +99,29 @@ function iterate(S::ResettableStack, state = S.cur)
     (S.data[state + 1], state)
 end
 
+"""
+    reset!(S::ResettableStack, force_reset=false)
+
+Reset the stack to an empty state without deallocating the internal buffer.
+
+This allows the stack to be reused efficiently by overwriting previous data instead of
+allocating new memory. Every `FULL_RESET_COUNT` resets (default: 10000), or when
+`force_reset=true`, the internal buffer is resized to half its current size if it has
+grown larger than 5 elements, preventing unbounded memory growth.
+
+# Arguments
+- `S::ResettableStack`: The stack to reset
+- `force_reset::Bool=false`: If true, forces a buffer resize regardless of reset count
+
+# Example
+```julia
+S = ResettableStack{true}(Float64)
+push!(S, 1.0)
+push!(S, 2.0)
+reset!(S)  # Stack is now empty but buffer is preserved
+push!(S, 3.0)  # Reuses existing buffer
+```
+"""
 function reset!(S::ResettableStack, force_reset = false)
     S.numResets += 1
     S.cur = 0


### PR DESCRIPTION
## Summary

This PR improves the documentation quality for ResettableStacks.jl:

- **Fixed typo**: "garbage control" → "garbage collection" in README.md:13
- **Updated installation instructions**: Replaced deprecated `Pkg.checkout()` with modern `Pkg.add(url=...)` syntax
- **Fixed syntax error**: Corrected README example from `ResettableStack{}(...)` to `ResettableStack{true}(...)` 
- **Added comprehensive docstrings**:
  - `ResettableStack` struct: Explains type parameters, fields, constructors, and includes usage example
  - `reset!` function: Details the reset behavior, arguments, and memory management strategy
- **Verified examples**: All code examples in README and docstrings have been tested and work correctly

## Test Plan

- ✅ All existing tests pass (`Pkg.test()`)
- ✅ README example runs without errors
- ✅ Docstrings display correctly in Julia REPL
- ✅ No formatting tools were run (as per instructions)

@ChrisRackauckas - Ready for review. These focused improvements make the package more user-friendly without changing any functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)