### PR TITLE
Centralize CI on SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,10 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,5 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,5 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the CI to use the centralized SciML/.github reusable workflows (pinned `@v1`), each caller getting `secrets: "inherit"`.

## Converted (inline -> central)
- **FormatCheck.yml** (Runic): inline `fredrikekre/runic-action` -> `runic.yml@v1`
- **SpellCheck.yml**: inline `crate-ci/typos` -> `spellcheck.yml@v1`
- **Downgrade.yml**: inline -> `downgrade.yml@v1`, preserving `julia-version: "1.10"`, `skip: "Pkg,TOML"`, and the existing `if: false` gate on the job

## Unchanged
- **Tests.yml**: already a `tests.yml@v1` caller with `secrets: "inherit"` (matrix `version: [1, lts, pre]` preserved as-is)
- **TagBot.yml**: left unchanged
- No `docs/` directory, so no Documentation caller added
- No downstream/IntegrationTest or benchmark workflows present, so none added
- No `CompatHelper.yml` present

## dependabot.yml
- Removed the `crate-ci/typos` version ignore
- `github-actions` block kept (`/`, weekly)
- `julia` block scoped to `/` (the only dir with a `Project.toml`; previous config also listed `/test`, which has no `Project.toml`); daily, group `all-julia-packages` `["*"]`

## Typos / Runic
- Typos auto-fix: 0 fixes needed (already clean)
- Runic: no formatting changes needed (already clean)

## Note
Check names will change (jobs now run via reusable workflows), so any branch-protection required-status-check names will need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)