### PR TITLE
Re-enable downgrade CI with genuine test-at-floor (allow_reresolve: false)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,7 +12,6 @@ on:
       - 'docs/**'
 jobs:
   downgrade:
-    if: false
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
       julia-version: "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 JET = "0.9, 0.10, 0.11"
-StaticArrays = "1.9"
+StaticArrays = "1.9.18"
 julia = "1.10"
 
 [extras]


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.** Draft. Re-enables the Downgrade workflow with allow_reresolve:false; verified locally on Julia 1.10, 0 re-resolve. CI is the gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)