### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the missing standard SciML centralized workflows so this repo matches the org-wide standard set. It only adds new caller files under `.github/workflows/` (no existing files, code, or `Project.toml` are touched).

Added:
- **RunicSuggestions.yml** — auto-format suggestions via `SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1` (this repo's format check uses Runic).
- **DependabotAutoMerge.yml** — `SciML/.github/.github/workflows/dependabot-automerge.yml@v1`.

The docs-preview-cleanup workflow was intentionally not added because this repo has no `docs/` Documenter site.

These are static caller files that delegate to the centralized reusable workflows; no local test run is applicable.

**Please ignore until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)