### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -14,15 +14,5 @@ concurrency:
 
 jobs:
   tests:
-    name: "Tests"
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - "1"
-          - "lts"
-          - "pre"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/Project.toml
+++ b/Project.toml
@@ -7,17 +7,18 @@ version = "1.2.0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-JET = "0.9, 0.10, 0.11"
+ArrayInterface = "7"
+JLArrays = "0.2, 0.3"
+Random = "1"
 StaticArrays = "1.9.18"
+Test = "1"
 julia = "1.10"
 
 [extras]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
-JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "ArrayInterface", "JLArrays", "JET", "ExplicitImports"]
+test = ["Test", "Random", "ArrayInterface", "JLArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -17,8 +17,9 @@ julia = "1.10"
 [extras]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 JLArrays = "27aeb0d3-9eb9-45fb-866b-73c2ecf80fcb"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random", "ArrayInterface", "JLArrays"]
+test = ["Test", "Random", "ArrayInterface", "JLArrays", "Pkg"]

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,0 +1,14 @@
+[deps]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+ResettableStacks = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[sources]
+ResettableStacks = { path = "../.." }
+
+[compat]
+ExplicitImports = "1"
+JET = "0.9, 0.10, 0.11"
+Test = "1"
+julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,0 +1,59 @@
+using ResettableStacks
+using Test
+using JET
+using ExplicitImports
+
+# JET static analysis tests
+@testset "JET static analysis" begin
+    # Test type stability of core operations
+    @testset "push!" begin
+        S = ResettableStack{}(Float64)
+        @test_opt target_modules = (ResettableStacks,) push!(S, 1.0)
+    end
+
+    @testset "pop!" begin
+        S = ResettableStack{}(Float64)
+        push!(S, 1.0)
+        @test_opt target_modules = (ResettableStacks,) pop!(S)
+    end
+
+    @testset "reset!" begin
+        S = ResettableStack{}(Float64)
+        push!(S, 1.0)
+        @test_opt target_modules = (ResettableStacks,) reset!(S)
+    end
+
+    @testset "iterate" begin
+        S = ResettableStack{}(Float64)
+        push!(S, 1.0)
+        @test_opt target_modules = (ResettableStacks,) iterate(S)
+    end
+
+    @testset "isempty" begin
+        S = ResettableStack{}(Float64)
+        @test_opt target_modules = (ResettableStacks,) isempty(S)
+    end
+
+    @testset "length" begin
+        S = ResettableStack{}(Float64)
+        @test_opt target_modules = (ResettableStacks,) length(S)
+    end
+
+    @testset "copyat_or_push! (iip=true)" begin
+        S = ResettableStack{true}(Tuple{Float64, Vector{Float64}, Vector{Float64}})
+        tuple = (1.0, [1.0, 2.0], [3.0, 4.0])
+        @test_opt target_modules = (ResettableStacks,) ResettableStacks.copyat_or_push!(S, tuple)
+    end
+
+    @testset "copyat_or_push! (iip=false)" begin
+        S = ResettableStack{false}(Tuple{Float64, Vector{Float64}, Vector{Float64}})
+        tuple = (1.0, [1.0, 2.0], [3.0, 4.0])
+        @test_opt target_modules = (ResettableStacks,) ResettableStacks.copyat_or_push!(S, tuple)
+    end
+end
+
+# ExplicitImports tests
+@testset "ExplicitImports" begin
+    @test check_no_implicit_imports(ResettableStacks) === nothing
+    @test check_no_stale_explicit_imports(ResettableStacks) === nothing
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,11 @@
 using Pkg
 
+using ResettableStacks
+using Test
+using Random
+using JLArrays
+using ArrayInterface
+
 const GROUP = get(ENV, "GROUP", "All")
 
 if GROUP == "QA"
@@ -10,12 +16,6 @@ if GROUP == "QA"
 end
 
 if GROUP in ("All", "Core")
-    using ResettableStacks
-    using Test
-    using Random
-    using JLArrays
-    using ArrayInterface
-
     S = ResettableStack{}(Tuple{Float64, Float64, Float64})
 
     push!(S, (0.5, 0.4, 0.3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,195 +1,151 @@
-using ResettableStacks
-using Test
-using Random
-using JLArrays
-using ArrayInterface
-using JET
+using Pkg
 
-S = ResettableStack{}(Tuple{Float64, Float64, Float64})
+const GROUP = get(ENV, "GROUP", "All")
 
-push!(S, (0.5, 0.4, 0.3))
-push!(S, (0.5, 0.4, 0.4))
-reset!(S)
-push!(S, (0.5, 0.4, 0.3))
-@test S.data[1] == (0.5, 0.4, 0.3)
-
-S = ResettableStack{}(Float64)
-for i in 1:10
-    push!(S, i)
-end
-@test pop!(S) == 10
-
-### Iterator tests
-s = ResettableStacks.ResettableStack{}(Float64)
-Random.seed!(100)
-expected_values = Float64[]
-for i in 1:6
-    v = rand()
-    push!(expected_values, v)
-    push!(s, v)
-end
-# Iterator returns values in reverse (LIFO) order
-reversed_expected = reverse(expected_values)
-for (i, c) in enumerate(s)
-    @test c == reversed_expected[i]
-end
-@test length(collect(s)) == 6
-reset!(s)
-new_val = rand()
-push!(s, new_val)
-for c in s
-    @test c == new_val
-end
-@test length(collect(s)) == 1
-
-### Interface tests
-
-# eltype tests
-@testset "eltype" begin
-    S = ResettableStack{}(Float64)
-    push!(S, 1.0)
-    @test eltype(S) == Float64
-    @test typeof(collect(S)) == Vector{Float64}
-
-    S2 = ResettableStack{}(BigFloat)
-    push!(S2, BigFloat(1.0))
-    @test eltype(S2) == BigFloat
-    @test typeof(collect(S2)) == Vector{BigFloat}
-
-    S3 = ResettableStack{}(Vector{Int})
-    push!(S3, [1, 2, 3])
-    @test eltype(S3) == Vector{Int}
-    @test typeof(collect(S3)) == Vector{Vector{Int}}
+if GROUP == "QA"
+    Pkg.activate(joinpath(@__DIR__, "qa"))
+    Pkg.develop(path = joinpath(@__DIR__, ".."))
+    Pkg.instantiate()
+    include(joinpath(@__DIR__, "qa", "qa.jl"))
 end
 
-# BigFloat support tests
-@testset "BigFloat support" begin
-    S = ResettableStack{}(BigFloat)
-    push!(S, BigFloat("3.14159265358979323846264338327950288419716939937510"))
-    push!(S, BigFloat("2.71828182845904523536028747135266249775724709369995"))
-    @test pop!(S) == BigFloat("2.71828182845904523536028747135266249775724709369995")
-    @test length(S) == 1
+if GROUP in ("All", "Core")
+    using ResettableStacks
+    using Test
+    using Random
+    using JLArrays
+    using ArrayInterface
 
-    # Test iteration
-    for item in S
-        @test item isa BigFloat
-    end
+    S = ResettableStack{}(Tuple{Float64, Float64, Float64})
 
-    # Test reset
+    push!(S, (0.5, 0.4, 0.3))
+    push!(S, (0.5, 0.4, 0.4))
     reset!(S)
-    @test isempty(S)
-end
+    push!(S, (0.5, 0.4, 0.3))
+    @test S.data[1] == (0.5, 0.4, 0.3)
 
-# JLArrays support tests (GPU-like arrays)
-@testset "JLArray support" begin
-    # Store JLArrays in a stack
-    S = ResettableStack{}(JLArray{Float64, 1})
-    x1 = JLArray([1.0, 2.0, 3.0])
-    x2 = JLArray([4.0, 5.0, 6.0])
-
-    push!(S, x1)
-    push!(S, x2)
-    @test length(S) == 2
-
-    result = pop!(S)
-    @test result isa JLArray{Float64, 1}
-
-    # Test iteration
-    for item in S
-        @test item isa JLArray{Float64, 1}
-    end
-
-    # Test reset
-    reset!(S)
-    @test isempty(S)
-end
-
-# copyat_or_push! tests with various types
-@testset "copyat_or_push! interface" begin
-    # Test with BigFloat arrays (in-place mode)
-    S = ResettableStack{true}(Tuple{BigFloat, Vector{BigFloat}, Vector{BigFloat}})
-    tuple1 = (BigFloat(1.0), BigFloat[1.0, 2.0, 3.0], BigFloat[4.0, 5.0, 6.0])
-    tuple2 = (BigFloat(2.0), BigFloat[7.0, 8.0, 9.0], BigFloat[10.0, 11.0, 12.0])
-
-    ResettableStacks.copyat_or_push!(S, tuple1)
-    ResettableStacks.copyat_or_push!(S, tuple2)
-    @test S.cur == 2
-
-    # Test with JLArrays (non-in-place mode)
-    S2 = ResettableStack{false}(Tuple{Float64, JLArray{Float64, 1}, JLArray{Float64, 1}})
-    t1 = (1.0, JLArray([1.0, 2.0, 3.0]), JLArray([4.0, 5.0, 6.0]))
-    t2 = (2.0, JLArray([7.0, 8.0, 9.0]), JLArray([10.0, 11.0, 12.0]))
-
-    ResettableStacks.copyat_or_push!(S2, t1)
-    ResettableStacks.copyat_or_push!(S2, t2)
-    @test S2.cur == 2
-    @test S2.data[1][2] isa JLArray
-end
-
-# ArrayInterface compatibility tests
-@testset "ArrayInterface compatibility" begin
     S = ResettableStack{}(Float64)
-    for i in 1:5
-        push!(S, Float64(i))
+    for i in 1:10
+        push!(S, i)
     end
+    @test pop!(S) == 10
 
-    # The internal data vector should work with ArrayInterface
-    @test ArrayInterface.can_setindex(S.data)
-    @test ArrayInterface.fast_scalar_indexing(S.data)
-end
-
-# JET static analysis tests
-@testset "JET static analysis" begin
-    # Test type stability of core operations
-    @testset "push!" begin
-        S = ResettableStack{}(Float64)
-        @test_opt target_modules = (ResettableStacks,) push!(S, 1.0)
+    ### Iterator tests
+    s = ResettableStacks.ResettableStack{}(Float64)
+    Random.seed!(100)
+    expected_values = Float64[]
+    for i in 1:6
+        v = rand()
+        push!(expected_values, v)
+        push!(s, v)
     end
+    # Iterator returns values in reverse (LIFO) order
+    reversed_expected = reverse(expected_values)
+    for (i, c) in enumerate(s)
+        @test c == reversed_expected[i]
+    end
+    @test length(collect(s)) == 6
+    reset!(s)
+    new_val = rand()
+    push!(s, new_val)
+    for c in s
+        @test c == new_val
+    end
+    @test length(collect(s)) == 1
 
-    @testset "pop!" begin
+    ### Interface tests
+
+    # eltype tests
+    @testset "eltype" begin
         S = ResettableStack{}(Float64)
         push!(S, 1.0)
-        @test_opt target_modules = (ResettableStacks,) pop!(S)
+        @test eltype(S) == Float64
+        @test typeof(collect(S)) == Vector{Float64}
+
+        S2 = ResettableStack{}(BigFloat)
+        push!(S2, BigFloat(1.0))
+        @test eltype(S2) == BigFloat
+        @test typeof(collect(S2)) == Vector{BigFloat}
+
+        S3 = ResettableStack{}(Vector{Int})
+        push!(S3, [1, 2, 3])
+        @test eltype(S3) == Vector{Int}
+        @test typeof(collect(S3)) == Vector{Vector{Int}}
     end
 
-    @testset "reset!" begin
+    # BigFloat support tests
+    @testset "BigFloat support" begin
+        S = ResettableStack{}(BigFloat)
+        push!(S, BigFloat("3.14159265358979323846264338327950288419716939937510"))
+        push!(S, BigFloat("2.71828182845904523536028747135266249775724709369995"))
+        @test pop!(S) == BigFloat("2.71828182845904523536028747135266249775724709369995")
+        @test length(S) == 1
+
+        # Test iteration
+        for item in S
+            @test item isa BigFloat
+        end
+
+        # Test reset
+        reset!(S)
+        @test isempty(S)
+    end
+
+    # JLArrays support tests (GPU-like arrays)
+    @testset "JLArray support" begin
+        # Store JLArrays in a stack
+        S = ResettableStack{}(JLArray{Float64, 1})
+        x1 = JLArray([1.0, 2.0, 3.0])
+        x2 = JLArray([4.0, 5.0, 6.0])
+
+        push!(S, x1)
+        push!(S, x2)
+        @test length(S) == 2
+
+        result = pop!(S)
+        @test result isa JLArray{Float64, 1}
+
+        # Test iteration
+        for item in S
+            @test item isa JLArray{Float64, 1}
+        end
+
+        # Test reset
+        reset!(S)
+        @test isempty(S)
+    end
+
+    # copyat_or_push! tests with various types
+    @testset "copyat_or_push! interface" begin
+        # Test with BigFloat arrays (in-place mode)
+        S = ResettableStack{true}(Tuple{BigFloat, Vector{BigFloat}, Vector{BigFloat}})
+        tuple1 = (BigFloat(1.0), BigFloat[1.0, 2.0, 3.0], BigFloat[4.0, 5.0, 6.0])
+        tuple2 = (BigFloat(2.0), BigFloat[7.0, 8.0, 9.0], BigFloat[10.0, 11.0, 12.0])
+
+        ResettableStacks.copyat_or_push!(S, tuple1)
+        ResettableStacks.copyat_or_push!(S, tuple2)
+        @test S.cur == 2
+
+        # Test with JLArrays (non-in-place mode)
+        S2 = ResettableStack{false}(Tuple{Float64, JLArray{Float64, 1}, JLArray{Float64, 1}})
+        t1 = (1.0, JLArray([1.0, 2.0, 3.0]), JLArray([4.0, 5.0, 6.0]))
+        t2 = (2.0, JLArray([7.0, 8.0, 9.0]), JLArray([10.0, 11.0, 12.0]))
+
+        ResettableStacks.copyat_or_push!(S2, t1)
+        ResettableStacks.copyat_or_push!(S2, t2)
+        @test S2.cur == 2
+        @test S2.data[1][2] isa JLArray
+    end
+
+    # ArrayInterface compatibility tests
+    @testset "ArrayInterface compatibility" begin
         S = ResettableStack{}(Float64)
-        push!(S, 1.0)
-        @test_opt target_modules = (ResettableStacks,) reset!(S)
-    end
+        for i in 1:5
+            push!(S, Float64(i))
+        end
 
-    @testset "iterate" begin
-        S = ResettableStack{}(Float64)
-        push!(S, 1.0)
-        @test_opt target_modules = (ResettableStacks,) iterate(S)
+        # The internal data vector should work with ArrayInterface
+        @test ArrayInterface.can_setindex(S.data)
+        @test ArrayInterface.fast_scalar_indexing(S.data)
     end
-
-    @testset "isempty" begin
-        S = ResettableStack{}(Float64)
-        @test_opt target_modules = (ResettableStacks,) isempty(S)
-    end
-
-    @testset "length" begin
-        S = ResettableStack{}(Float64)
-        @test_opt target_modules = (ResettableStacks,) length(S)
-    end
-
-    @testset "copyat_or_push! (iip=true)" begin
-        S = ResettableStack{true}(Tuple{Float64, Vector{Float64}, Vector{Float64}})
-        tuple = (1.0, [1.0, 2.0], [3.0, 4.0])
-        @test_opt target_modules = (ResettableStacks,) ResettableStacks.copyat_or_push!(S, tuple)
-    end
-
-    @testset "copyat_or_push! (iip=false)" begin
-        S = ResettableStack{false}(Tuple{Float64, Vector{Float64}, Vector{Float64}})
-        tuple = (1.0, [1.0, 2.0], [3.0, 4.0])
-        @test_opt target_modules = (ResettableStacks,) ResettableStacks.copyat_or_push!(S, tuple)
-    end
-end
-
-# ExplicitImports tests
-@testset "ExplicitImports" begin
-    using ExplicitImports
-    @test check_no_implicit_imports(ResettableStacks) === nothing
-    @test check_no_stale_explicit_imports(ResettableStacks) === nothing
 end

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,5 @@
+[Core]
+versions = ["lts", "1", "pre"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
## Summary

Converts the root **Tests** workflow to the canonical thin caller (`SciML/.github` `grouped-tests.yml@v1`), with the test matrix declared once in a root `test/test_groups.toml`.

- `.github/workflows/Tests.yml`: the hand-maintained `version` matrix job is replaced by a thin caller to `grouped-tests.yml@v1` (`secrets: inherit`, no `with:` overrides needed — root reads `GROUP`, Linux-only, default coverage). `on:` and `concurrency:` preserved verbatim. Other workflows untouched.
- `test/test_groups.toml`:
  - `[Core]` on `["lts", "1", "pre"]`
  - `[QA]` on `["lts", "1"]`

## Category B refactor (inline QA → isolated QA group)

JET and ExplicitImports previously ran **inline** in `runtests.jl` on every Julia version, with no separate QA group. They are now:
- moved into a `GROUP == "QA"` path in `runtests.jl` that `Pkg.activate`s an isolated `test/qa/Project.toml` (deps: JET, ExplicitImports, Test, and ResettableStacks via `[sources]` path), `Pkg.develop`s the package, `Pkg.instantiate`s, then `include`s `test/qa/qa.jl`;
- functional tests stay under `GROUP` `Core`/`All` in the main test env.

No tests or QA checks were skipped, silenced, or excluded — they were relocated verbatim into the QA group.

`Project.toml`: JET/ExplicitImports dropped from root `[extras]`/`[targets]`/`[compat]` (now in the qa env); added `[compat]` entries for every remaining test extra (ArrayInterface, JLArrays, Random, Test). `julia` compat was already `"1.10"`.

## Matrix match

`compute_affected_sublibraries.jl --root-matrix` (run under Julia 1.11) emits:

- `Core` × {`lts`, `1`, `pre`}  — reproduces the OLD per-version matrix (`["1","lts","pre"]`) for the functional suite
- `QA` × {`lts`, `1`}  — newly wired isolated quality group

The OLD matrix was 3 jobs (one per version) running the whole suite (functional + JET + ExplicitImports). Core preserves the functional coverage on the identical version set; QA isolates the quality checks.

QA group newly wired; Aqua/JET run in CI — any failures will be triaged in follow-up. (This package uses JET + ExplicitImports; no Aqua.)

---

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)