### PR TITLE
Add public API docs coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For the latest development version:
 
 ```julia
 using Pkg
-Pkg.add(url="https://github.com/SciML/ResettableStacks.jl")
+Pkg.add(url = "https://github.com/SciML/ResettableStacks.jl")
 ```
 
 ## Usage

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ResettableStacks = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
+
+[compat]
+Documenter = "1"
+ResettableStacks = "1"
+julia = "1.10"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,22 @@
+using Pkg
+
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+Pkg.instantiate()
+
+using Documenter
+using ResettableStacks
+
+DocMeta.setdocmeta!(ResettableStacks, :DocTestSetup, :(using ResettableStacks); recursive = true)
+
+makedocs(;
+    modules = [ResettableStacks],
+    authors = "Chris Rackauckas",
+    sitename = "ResettableStacks.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true"
+    ),
+    pages = [
+        "Home" => "index.md",
+    ],
+    checkdocs = :exports
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,32 @@
+# ResettableStacks.jl
+
+## Overview
+
+`ResettableStacks.jl` provides a stack type whose storage can be reused across resets.
+
+## Installation
+
+```julia
+using Pkg
+Pkg.add("ResettableStacks")
+```
+
+## Usage
+
+```julia
+using ResettableStacks
+
+S = ResettableStack{true}(Tuple{Float64, Float64, Float64})
+push!(S, (0.5, 0.4, 0.3))
+push!(S, (0.5, 0.4, 0.4))
+reset!(S)
+push!(S, (0.5, 0.4, 0.3))
+tup = pop!(S)
+```
+
+## API
+
+```@docs
+ResettableStack
+reset!
+```

--- a/src/core.jl
+++ b/src/core.jl
@@ -31,7 +31,7 @@ val = pop!(S)  # returns 2.0
 reset!(S)      # efficiently resets the stack
 ```
 
-See also: [`reset!`](@ref), [`push!`](@ref), [`pop!`](@ref)
+See also: [`reset!`](@ref), `push!`, `pop!`
 """
 mutable struct ResettableStack{T, iip}
     data::Vector{T}
@@ -101,7 +101,7 @@ function iterate(S::ResettableStack, state = S.cur)
 end
 
 """
-    reset!(S::ResettableStack, force_reset=false)
+    reset!(S::ResettableStack, force_reset = false)
 
 Reset the stack to an empty state without deallocating the internal buffer.
 

--- a/test/qa/public_docs.jl
+++ b/test/qa/public_docs.jl
@@ -1,0 +1,61 @@
+using ResettableStacks
+using Test
+
+@testset "Public API documentation" begin
+    package_root = normpath(joinpath(@__DIR__, "..", ".."))
+    src_dir = joinpath(package_root, "src")
+    docs_src_dir = joinpath(package_root, "docs", "src")
+
+    @test startswith(normpath(pathof(ResettableStacks)), src_dir)
+
+    src_text = join(
+        String[
+            read(joinpath(root, file), String)
+                for (root, _, files) in walkdir(src_dir)
+                for file in files if endswith(file, ".jl")
+        ],
+        "\n"
+    )
+    docs_text = join(
+        String[
+            read(joinpath(root, file), String)
+                for (root, _, files) in walkdir(docs_src_dir)
+                for file in files if endswith(file, ".md")
+        ],
+        "\n"
+    )
+
+    @test !occursin(r"(?m)^\s*public\b", src_text)
+    @test !occursin(r"@public\b", src_text)
+    @test !occursin(r"SciMLPublic", src_text)
+
+    exported_names = setdiff(names(ResettableStacks), [nameof(ResettableStacks)])
+    @test sort(exported_names) == [:ResettableStack, :reset!]
+
+    documented_bindings = Set{String}()
+    in_docs_block = false
+    for line in split(docs_text, '\n')
+        stripped = strip(line)
+        if startswith(stripped, "```@docs")
+            in_docs_block = true
+        elseif startswith(stripped, "```")
+            in_docs_block = false
+        elseif in_docs_block && !isempty(stripped)
+            push!(documented_bindings, replace(stripped, "ResettableStacks." => ""))
+        end
+    end
+
+    @test occursin(
+        Regex("(?s)\"\"\"\\s+ResettableStack\\{T, iip\\}.*?\"\"\"\\s+mutable struct ResettableStack"),
+        src_text
+    )
+    @test occursin(
+        Regex("(?s)\"\"\"\\s+reset!\\(S::ResettableStack, force_reset = false\\).*?\"\"\"\\s+function reset!"),
+        src_text
+    )
+
+    for name in exported_names
+        @test haskey(Docs.meta(ResettableStacks), Docs.Binding(ResettableStacks, name))
+        @test string(name) in documented_bindings
+    end
+end

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,5 @@
 using SciMLTesting, ResettableStacks, JET, Test
 
+include("public_docs.jl")
+
 run_qa(ResettableStacks; explicit_imports = true)


### PR DESCRIPTION
## Summary

This PR adds a minimal Documenter docs tree for ResettableStacks.jl and renders the exported API docstrings for `ResettableStack` and `reset!` through an `@docs` block. It also adds a focused QA guard that verifies the exported public surface has definition-point source docstrings and appears in the docs source.

Ignore this PR until reviewed by @ChrisRackauckas.

## Validation

- `rg -n "^\\s*(export|public)\\b|@public\\b|SciMLPublic" src docs/src Project.toml docs/Project.toml README.md`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=docs docs/make.jl`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/public_docs.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=. -e 'using Pkg; Pkg.test()'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 --project=test/qa -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("test/qa/qa.jl")'`
- `timeout 3600 /home/crackauc/.juliaup/bin/julia +1.10 -e 'using Pkg; Pkg.activate(; temp=true); Pkg.add("Runic"); using Runic; exit(Runic.main(["--check", "--diff", "--docstrings", "--extensions=jl,md", "."]))'`
- `git diff --cached --check`