### PR TITLE
Release prep: bump ResettableStacks to 1.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ResettableStacks"
 uuid = "ae5879a3-cd67-5da8-be7f-38c6eb64a37b"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"


### PR DESCRIPTION
Patch release for accumulated docstring/QA/test scaffolding changes since 1.2.2 (no functional/API changes).