### PR TITLE
Use default public API docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,3 +1,3 @@
 using SciMLTesting, ResettableStacks, JET
 
-run_qa(ResettableStacks; explicit_imports = true, api_docs_kwargs = (; rendered = true))
+run_qa(ResettableStacks; explicit_imports = true)


### PR DESCRIPTION
Remove the repository-specific rendered API-docs option and use the standard SciMLTesting public API documentation check.

Validation:
- Runic 1.7 with docstrings
- `GROUP=QA Pkg.test()`
- `Pkg.test()`

Ignore until reviewed by @ChrisRackauckas.